### PR TITLE
Removing user from new_user after kick

### DIFF
--- a/gdgpisausermanager.py
+++ b/gdgpisausermanager.py
@@ -178,6 +178,7 @@ def timer(bot, user_id, chat_id, message_id):
     """
     if user_id in new_users:
         logger.info("User with id: {} auto-removed with success".format(user_id))
+        new_users.remove(user_id) 
         bot.kick_chat_member(chat_id, user_id, until_date=maxsize)  # Kicking a member for over 365 days is forever
         bot.delete_message(chat_id, message_id=message_id)
 


### PR DESCRIPTION
fixes #15 

Removing the kicked user from new_user list after the user is kicked out. If the user will be added again and complete the registration in the same instance of the bot, he/she won't be kicked out

### Checklist:

* [x] Have you tested the bot locally?
* [x] Have you checked the logs?
* [ ] Have you commented your code?
